### PR TITLE
Update dnf.py to fix the documentation (--skip-broken)

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -120,7 +120,7 @@ options:
     default: []
   skip_broken:
     description:
-      - Skip all unavailable packages or packages with broken dependencies
+      - Skip all packages with broken dependencies
         without raising an error. Equivalent to passing the --skip-broken option.
     type: bool
     default: "no"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated skip_broken parameter
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The `skip_broken` parameter supposed to follow `--skip-broken` parameter/argument in the `dnf` command. So the wording has been adjusted as follows:

Before"
```
Skip all unavailable packages or packages with broken dependencies without raising an error. Equivalent to passing the –skip-broken option.
```

After:
```
Skip packages with broken dependencies without raising an error. Equivalent to passing the –skip-broken option.
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
